### PR TITLE
Create submodule for transportation modeling data import cleaning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_transportation/data-raw/metc_travel_model"]
+	path = _transportation/data-raw/metc_travel_model
+	url = git@github.com:Metropolitan-Council/metc_travel_model.git

--- a/.renvignore
+++ b/.renvignore
@@ -50,3 +50,5 @@ _transportation/data-raw/mndot/~$Current_CC_StationList.xlsx
 _transportation/data-raw/wisdot_vmt_county.R
 
 docs/_transportation/data-raw/wisdot_vmt_county.R
+
+_transportation/data-raw/metc_travel_model/

--- a/metcouncil-cprg-ghg.bib
+++ b/metcouncil-cprg-ghg.bib
@@ -474,7 +474,7 @@
   url = {https://www.epa.gov/system/files/documents/2024-03/indianapolis-cprg-cirda-pcap-report.pdf},
   urldate = {2024-03-06},
   abstract = {Central Indiana Regional Development Authority (CIRDA) was awarded a \$1 million planning grant from the U.S. Environmental Protection Agency (EPA) to develop regional plans for Central Indiana focused on strategies to reduce greenhouse gas (GHG) emissions and other harmful air pollution. The grant is part of EPA’s Climate Pollution Reduction Grants (CPRG) program. 1 CLIMATE POLLUTION REDUCTION GRANT OVERVIEW The CPRG program provides \$5 billion in grants to states, local governments, tribes, and territories to develop and implement ambitious plans for reducing GHG emissions and other harmful air pollution. CPRG is authorized under Section 60114 of the Inflation Reduction Act,2 and consists of two phases: Phase 1 provides \$250 million for noncompetitive planning grants, and Phase 2 provides approximately \$4.6 billion for competitive implementation grants. Phase 1 of the CPRG program provides flexible support to states, local governments, tribes, and territories for climate planning. Planning grant recipients must design climate action plans that incorporate a variety of measures to reduce GHG emissions from across their economies in the following key sectors: electricity generation, industry, transportation, buildings, agriculture, natural and working lands, and waste management. All planning grantees must submit the following deliverables to EPA: • Priority Climate Action Plan (PCAP) – A PCAP is a narrative report that includes a focused list of near-term, high-priority, and implementation-ready measures to reduce GHG pollution and an analysis of GHG emissions reductions. PCAPs for states and metropolitan statistical areas 1 U.S. Environmental Protection Agency (EPA). 2023. “Climate Pollution Reduction Grants.” Modified 5 February 2024. Retrieved from: https://www.epa.gov/inflation-reduction-act/climate-pollution-reduction-grants 2 U.S. Congress. 2022. H.R.5376 - Inflation Reduction Act of 2022. Online posting. Modified 16 August 2022. Retrieved from: https://www.congress.gov/bill/117th-congress/house-bill/5376/text  CIRDA Priority Climate Action Plan 2024 12 (MSAs) are due to EPA on 1 March 2024, and on 1 April 2024 for tribes, tribal consortia, and territories. • Comprehensive Climate Action Plan (CCAP) – A CCAP is a narrative report that provides an overview of the grantees’ significant GHG sources/sinks and sectors, establishes near-term and long-term GHG emission reduction goals, and provides strategies and identifies measures that address the highest priority sectors to help the grantees meet those goals. CCAPs for states and MSAs are due to EPA 2 years after the planning grant award, or approximately mid-2025, and CCAPs for tribes, tribal consortia, and territories are due at the close of the grant period. • Status Report – A Status Report should include the implementation status of the quantified GHG reduction measures included in the CCAP; any relevant updated analyses or projections supporting CCAP implementation; and next steps and future budget/staffing needs to continue CCAP implementation. Status Reports are due to EPA at the end of the 4-year grant period (approximately mid-2027) for state and MSA grantees. Phase 2 of the CPRG program provides \$4.6 billion in competitive grants to support the implementation of measures identified in the PCAP developed with Phase 1 planning grant funding. This funding is open to entities that received planning grants, as well as eligible entities that did not directly receive a planning grant that are applying for funds to implement measures included in an applicable PCAP. Applications for Phase 2 implementation grants are due to the EPA on 1 April 2024, for states and MSAs. EPA’s key objectives for the CPRG program include the following: • Tackle damaging climate pollution while supporting the creation of good jobs and lowering energy costs for families. • Accelerate work to address environmental injustice and empower community-driven solutions in overburdened neighborhoods. • Deliver cleaner air by reducing harmful air pollution in places where people live, work, play, and go to school.},
-  keywords = {Regional PCAP}
+  keywords = {Regional PCAP,transportation ghg method: DOT VMT,transportation ghg method: LGGIT}
 }
 
 @report{cityandcountyofhonoluluPriorityClimateAction2024,
@@ -523,10 +523,11 @@
   shorttitle = {Austin {{PCAP}}},
   author = {{City of Austin} and Lilauwala, Rohan and Duran, Phillip and Calvo, Mali and Udita, Tasnuva},
   date = {2024-03-01},
+  pages = {1--66},
   institution = {City of Austin Office of Sustainability},
   location = {Austin, TX},
   url = {https://www.epa.gov/system/files/documents/2024-03/city-of-austin-austin-rrock-georgetown-pcap.pdf},
-  urldate = {2024-03-06},
+  urldate = {2025-01-28},
   abstract = {The City of Austin has partnered with cities, counties, regional organizations, and utilities in the Austin-Round Rock-Georgetown MSA to produce this priority climate action plan (PCAP) to support investment in policies, practices, and technologies that reduce Greenhouse Gas (GHG) emissions, provide other environmental benefits, create high-quality jobs, spur economic growth, and enhance the quality of life in the Austin-Round Rock-Georgetown MSA. This plan aims to highlight priority measures for regional greenhouse gas reductions, addressing the dispersed authority across water, housing, transportation, and resource conservation through planning at the regional level. The Austin region is one of the fastest-growing metropolitan statistical areas 1 in the country, and this plan represents an innovative approach to fostering collaboration in climate planning. Several participating municipalities have already undertaken steps to mitigate climate change and reduce GHG emissions, including climate-focused strategies and initiatives in their comprehensive, strategic, and vision plans. Notably, the City of Austin and Travis County have directed plans exclusive to climate planning — the City of Austin Climate Equity Plan and the Travis County Climate Action Plan. This PCAP represents an opportunity to work across municipalities, building on the alignment across plans that pertain to greenhouse gas reduction and leveraging the implementation authority across each of the participating cities, counties, and regional planning organizations. These GHG reduction and climate goals are also reflected at the federal level. Measures developed from the PCAP will support Objective 1.1 of EPA’s Strategic Plan, “Reduce Emissions that Cause Climate Change,” and support compliance with the National Ambient Air Quality Standards outlined in the Austin MSA Regional Air Quality Plan.}
 }
 
@@ -556,7 +557,7 @@
   url = {https://www.epa.gov/system/files/documents/2024-03/city-of-birmingham-pcap.pdf},
   urldate = {2024-03-05},
   abstract = {In 2023 the EPA allocated funding to the Birmingham-Hoover MSA in order to develop a climate action plan; the plan is required to include an inventory of greenhouse gases emitted in the MSA over a one-year time period, and emissions reduction strategies that could be implemented. The City of Birmingham elected to lead the climate action planning process, with the support of the Regional Planning Commission of Greater Birmingham (RPCGB). The first iteration of the plan is the Priority Climate Action Plan (PCAP), which is this document. The PCAP is required to include an inventory of one emissions sector out of six: Agriculture and Open Space Buildings Energy Production Industry Transportation Waste The Birmingham-Hoover MSA PCAP focuses on transportation sector emissions and projects to reduce those emissions. The City of Birmingham will conduct a Comprehensive Climate Action Plan (CCAP), which we intend to complete by Fall of 2025. We will then focus on implementation of key projects from the CCAP until Fall 2027, at which point the CPRG planning effort will conclude.},
-  keywords = {Regional PCAP}
+  keywords = {Regional PCAP,transportation ghg method: MOVES}
 }
 
 @report{cityofbowlinggreenBowlingGreenMetropolitan2024,
@@ -1250,10 +1251,16 @@
   abstract = {Facility Level Information on Greenhouse Gases Tool}
 }
 
-@article{epaUSERGUIDEESTIMATING2024,
-  title = {{{USER}}’{{S GUIDE FOR ESTIMATING CARBON DIOXIDE}}, {{METHANE}}, {{AND NITROUS OXIDE EMISSIONS FROM AGRICULTURE USING THE STATE INVENTORY TOOL}}},
-  author = {EPA},
-  date = {2024},
+@report{epaUSERGUIDEESTIMATING2024,
+  type = {Government},
+  title = {User’s {{Guide For Estimating Carbon Dioxide}}, {{Methane}}, {{And Nitrous Oxide Emissions From Agriculture Using}} the {{State Inventory Tool}}},
+  author = {{USEPA} and {ICF}},
+  date = {2023-06},
+  pages = {1--31},
+  institution = {US EPA},
+  url = {https://www.epa.gov/system/files/documents/2023-06/Ag%20Module%20User%27s%20Guide_508.pdf},
+  urldate = {2025-01-28},
+  abstract = {This section of the User’s Guide provides instruction on using the CO2, CH4, and N2O from Agriculture (Ag) module of the State Inventory Tool (SIT), and describes the methodology used for estimating greenhouse gas emissions from agriculture at the state level.},
   langid = {english}
 }
 
@@ -1493,7 +1500,7 @@
 
 @report{gnrcPriorityClimateAction2024,
   type = {Government},
-  title = {Priority {{Climate Action Plan Nashville-Davidson-MurfreesboroFranklin}}, {{TN MSA}}},
+  title = {Priority {{Climate Action Plan Nashville-Davidson-Murfreesboro Franklin}}, {{TN MSA}}},
   shorttitle = {Nashville {{PCAP}}},
   author = {{GNRC}},
   date = {2024-03},
@@ -1522,9 +1529,12 @@
 }
 
 @report{greatriverenergy2021AnnualReport2022,
-  title = {2021 {{Annual Report}}},
-  author = {Great River Energy},
-  date = {2022},
+  title = {Powering What's Possible: 2021 {{Annual Report}}},
+  author = {{Great River Energy}},
+  date = {2022-04},
+  pages = {1-5-},
+  institution = {Great River Energy},
+  location = {Maple Grove, MN},
   url = {https://greatriverenergy.com/wp-content/uploads/2022/04/2021-GRE-Annual-Report-FINAL.pdf},
   urldate = {2024-02-15}
 }
@@ -1849,20 +1859,7 @@
   keywords = {Regional PCAP}
 }
 
-@report{icfUserGuideIncorporating2023,
-  title = {User’s {{Guide}} to {{Incorporating Existing GHG Inventories}} for the {{Priority Climate Action Plan}} ({{PCAP}})},
-  author = {{ICF}},
-  date = {2023-10},
-  pages = {1--6},
-  institution = {{US EPA, State and Local Climate and Energy Program}},
-  location = {Arlington, VA},
-  url = {https://www.epa.gov/system/files/documents/2024-01/guide-to-incorporating-existing-ghg-inventories-into-a-pcap.pdf},
-  urldate = {2024-07-03},
-  abstract = {The purpose of this document is to provide guidance for metropolitan statistical areas (MSAs)1 developing or compiling greenhouse gas (GHG) inventories for their priority climate action plans (PCAPs) under the Climate Pollution Reduction Grant (CPRG) Program of the US Environmental Protection Agency’s (EPA). 2 Figure 1 provides an overview of the key steps for developing an MSA-wide GHG inventory. This guide provides information particularly related to defining the scale of the inventory, collecting and compiling data, and setting a base year to aid localities with incorporating existing inventories into their PCAP.},
-  langid = {english}
-}
-
-@report{icfUsersGuideMinnesota22,
+@report{icfMICEUsersGuide2022,
   type = {Government},
   title = {Users {{Guide}}: {{Minnesota Infrastructure Carbon Estimator}} ({{MICE}}) Version 2.1},
   author = {{ICF}},
@@ -1874,6 +1871,19 @@
   url = {https://edocs-public.dot.state.mn.us/edocs_public/DMResultSet/download?docId=36622964},
   urldate = {2023-12-14},
   abstract = {The Infrastructure Carbon Estimator (ICE) is a spreadsheet tool that estimates the lifecycle energy and greenhouse gas (GHG) emissions from the construction and maintenance of transportation facilities. The ICE tool was created to solve the problem of “planning level” estimation of embodied carbon emissions in transportation infrastructure. Without the need for any engineering studies, ICE helps answer this question: How much carbon will be embodied in the building, modification, and/or maintenance of this transportation project (or group of projects)? The inputs to ICE are designed to be as simple as possible to source and input while still producing a reasonable analysis. The primary inputs required by the tool are metrics that should be readily available, such as roadway lane miles, rail track miles, or number of bridges, signs, or lights. ICE is designed to be self-explanatory. ICE includes detailed instructions and explanations of key input parameters in the tool itself. These are included as text in the tool as well as using Excel’s comment windows to populate “pop-up” windows with useful information.},
+  langid = {english}
+}
+
+@report{icfUserGuideIncorporating2023,
+  title = {User’s {{Guide}} to {{Incorporating Existing GHG Inventories}} for the {{Priority Climate Action Plan}} ({{PCAP}})},
+  author = {{ICF}},
+  date = {2023-10},
+  pages = {1--6},
+  institution = {{US EPA, State and Local Climate and Energy Program}},
+  location = {Arlington, VA},
+  url = {https://www.epa.gov/system/files/documents/2024-01/guide-to-incorporating-existing-ghg-inventories-into-a-pcap.pdf},
+  urldate = {2024-07-03},
+  abstract = {The purpose of this document is to provide guidance for metropolitan statistical areas (MSAs)1 developing or compiling greenhouse gas (GHG) inventories for their priority climate action plans (PCAPs) under the Climate Pollution Reduction Grant (CPRG) Program of the US Environmental Protection Agency’s (EPA). 2 Figure 1 provides an overview of the key steps for developing an MSA-wide GHG inventory. This guide provides information particularly related to defining the scale of the inventory, collecting and compiling data, and setting a base year to aid localities with incorporating existing inventories into their PCAP.},
   langid = {english}
 }
 
@@ -1935,18 +1945,12 @@
   keywords = {Regional PCAP}
 }
 
-@book{ipccAR62021,
-  title = {Climate {{Change}} 2021 – {{The Physical Science Basis}}: {{Working Group I Contribution}} to the {{Sixth Assessment Report}} of the {{Intergovernmental Panel}} on {{Climate Change}}},
-  shorttitle = {Climate {{Change}} 2021 – {{The Physical Science Basis}}},
-  author = {{IPCC}},
-  date = {2023-07-06},
-  edition = {1},
-  publisher = {Cambridge University Press},
-  doi = {10.1017/9781009157896},
-  url = {https://www.cambridge.org/core/product/identifier/9781009157896/type/book},
-  urldate = {2024-05-30},
-  abstract = {The Working Group I contribution to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC) provides a comprehensive assessment of the physical science basis of climate change. It considers in situ and remote observations; paleoclimate information; understanding of climate drivers and physical, chemical, and biological processes and feedbacks; global and regional climate modelling; advances in methods of analyses; and insights from climate services. It assesses the current state of the climate; human influence on climate in all regions; future climate change including sea level rise; global warming effects including extremes; climate information for risk assessment and regional adaptation; limiting climate change by reaching net zero carbon dioxide emissions and reducing other greenhouse gas emissions; and benefits for air quality. The report serves policymakers, decision makers, stakeholders, and all interested parties with the latest policy-relevant information on climate change. Available as Open Access on Cambridge Core.},
-  isbn = {978-1-00-915789-6}
+@report{incorporatedElectricGasWater2022,
+  title = {Electric, {{Gas}} or {{Water Annual Report}} to {{Public Service Commission}} of {{Wisconsin}} (2021)},
+  author = {Incorporated, Midwest Natural Gas},
+  date = {2022},
+  url = {https://apps.psc.wi.gov/PDFfiles/Annual%20Reports/IOU/IOU_2021_3670.pdf},
+  urldate = {2024-01-24}
 }
 
 @report{ipccClimateChange2014,
@@ -1962,6 +1966,20 @@
   url = {https://www.ipcc.ch/assessment-report/ar5/},
   urldate = {2024-01-30},
   langid = {english}
+}
+
+@book{ipccClimateChange20212023,
+  title = {Climate {{Change}} 2021 – {{The Physical Science Basis}}: {{Working Group I Contribution}} to the {{Sixth Assessment Report}} of the {{Intergovernmental Panel}} on {{Climate Change}}},
+  shorttitle = {Climate {{Change}} 2021 – {{The Physical Science Basis}}},
+  author = {{IPCC}},
+  date = {2023-07-06},
+  edition = {1},
+  publisher = {Cambridge University Press},
+  doi = {10.1017/9781009157896},
+  url = {https://www.cambridge.org/core/product/identifier/9781009157896/type/book},
+  urldate = {2024-05-30},
+  abstract = {The Working Group I contribution to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC) provides a comprehensive assessment of the physical science basis of climate change. It considers in situ and remote observations; paleoclimate information; understanding of climate drivers and physical, chemical, and biological processes and feedbacks; global and regional climate modelling; advances in methods of analyses; and insights from climate services. It assesses the current state of the climate; human influence on climate in all regions; future climate change including sea level rise; global warming effects including extremes; climate information for risk assessment and regional adaptation; limiting climate change by reaching net zero carbon dioxide emissions and reducing other greenhouse gas emissions; and benefits for air quality. The report serves policymakers, decision makers, stakeholders, and all interested parties with the latest policy-relevant information on climate change. Available as Open Access on Cambridge Core.},
+  isbn = {978-1-00-915789-6}
 }
 
 @report{irishSLOPEScenarioPlanner2021,
@@ -2019,7 +2037,7 @@
   keywords = {CBEI,CoolClimateNetwork}
 }
 
-@article{jonesSpatialDistributionHousehold2014,
+@article{jonesSpatialDistributionUS2014,
   title = {Spatial {{Distribution}} of {{U}}.{{S}}. {{Household Carbon Footprints Reveals Suburbanization Undermines Greenhouse Gas Benefits}} of {{Urban Population Density}}},
   author = {Jones, Christopher and Kammen, Daniel M.},
   date = {2014-01-21},
@@ -2269,6 +2287,20 @@
   issue = {11},
   langid = {english},
   keywords = {emissions inventory,GHG,greenhouse gases,public policy,urban mobility,urban transport}
+}
+
+@article{lovelaceEvaluatingPerformanceIterative2015,
+  title = {Evaluating the {{Performance}} of {{Iterative Proportional Fitting}} for {{Spatial Microsimulation}}: {{New Tests}} for an {{Established Technique}}},
+  shorttitle = {Evaluating the {{Performance}} of {{Iterative Proportional Fitting}} for {{Spatial Microsimulation}}},
+  author = {Lovelace, Robin and Birkin, Mark and Ballas, Dimitris and van Leeuwen, Eveline},
+  options = {useprefix=true},
+  date = {2015},
+  journaltitle = {Journal of Artificial Societies and Social Simulation},
+  shortjournal = {JASSS},
+  volume = {18},
+  number = {2},
+  pages = {21},
+  issn = {1460-7425}
 }
 
 @article{luExploringEffectsLand2023,
@@ -2959,7 +2991,7 @@
   abstract = {Purpose This report outlines the methodologies of the Metropolitan Washington Council of Governments’ (COG) greenhouse gas (GHG) inventory work, providing for completeness, consistency, accuracy, replicability, transparency, and quality control. The ability to develop relevant, robust sets of inventories supports COG’s Climate, Energy and Environment Policy Committee (CEEPC) and member local governments track progress towards GHG emission reduction goals and support decisionmaking around policies and programs that support emission reduction. Background COG’s Climate, Energy and Environment Policy Committee (CEEPC) was created by the COG Board in 2009 and is responsible for managing implementation of the National Capital Region Climate Change Report adopted by the COG Board in 2008. Since its inception, CEEPC has made it a priority to track progress towards emissions reduction and set goals for all COG members and the region to complete GHG inventories. Over the next five years, COG supported its members on inventory development by coordinating GHG inventory work group meetings and a series of trainings with national experts from ICLEI. COG also participated in development of a national protocol for local community-scale inventories, provided consultant support for COG member local inventory development, and began working on applying consistent methodologies across jurisdictions. Members of both CEEPC and its sub-committees requested additional support to ensure 100 percent of COG members were able to have consistent, comparable GHG inventories completed and have updates on their inventories completed to track progress towards GHG emission reduction goals. COG has completed local and regional GHG inventories for all COG members, northern Virginia, and metropolitan Washington for 2005, 2012, 2015, 2018, and 2020. Methodology Basics COG completes GHG community-scale inventories for all 24 local government members, northern Virginia, and metropolitan Washington. COG makes every effort to capture an accurate picture of GHG trends for each of its local government members, while also providing for a consistently applied methodology across all its members’ communities. Local inventory results are added together to get the total regional GHG emissions. COG GHG inventories are compliant with both the U.S. Communities Protocol for Accounting and Reporting Greenhouse Gas Emissionsi (USCP) and Global Protocol for Community-Scale Greenhouse Gas Inventoriesii (GPC). The Protocols provide guidance on what emission types should at minimum be included in all local community GHG inventories. Additional guidance on approaches to calculating emissions are offered, but not prescribed. COG mainly follows the calculation guidance from USCP as the USCP identifies sources of data widely available to communities in the US. If COG Greenhouse Gas Emissions Inventories Methodology Guide I 2 has reliable local data available that could provide more accurate results, then an alternative approach, calculation, or tool is used. For specific methodology information by emissions activity or source, see Appendix A. COG inventories use public data readily-available on a consistent basis for all its local government members. Data sources used must be available for past, current, and potential future inventories to accurately capture trends. While both accuracy and consistency are important to GHG inventories, consistency will be given a higher priority. Consistent Global Warming Potential (GWP) Factors are applied across the inventory years. COG inventories use GWP Factors from the Intergovernmental Panel on Climate Change Fourth Assessment Report (IPCC AR4), which is consistent with the EPA MOVES model leveraged for the regional transportation plan and on-road GHG calculations. Any models used, such as the MOVES model, are applied as consistently as possible. If a new version of the model is used, it will be noted. Appendices B, C, and D have additional information on data needs and availability, emission factors, and changes to data, models, and methods. COG inventories follow an activities-based approach, meaning emissions are calculated based on the result of an activity happening in a community. An example of this is that solid waste emissions are calculated based on the tonnage of trash the community sends to a landfill(s). Simply because they do not have a landfill within their jurisdiction’s boundaries, does not mean that they are not contributing to landfill emissions. The broad categories of emission types covered by COG’s GHG inventory work include the built environment (including some process and fugitive emissions), transportation and mobile emissions, waste (solid waste and wastewater), and some land use (agriculture, forests, and trees outside of forests). Most of these are required elements to be compliant with the USCP and GPC. Neither require land use; however, it was requested for inclusion by COG member jurisdictions (Table 1).}
 }
 
-@report{mwcogImplementationConsiderationsRoad2024,
+@report{mwcogImplementationConsiderationsOnRoad2024,
   type = {Government},
   title = {Implementation {{Considerations}} for {{On-Road Greenhouse Gas Emissions Reduction Strategies}}},
   author = {{MWCOG}},
@@ -3134,7 +3166,7 @@
   abstract = {New Jersey is warming faster than the rest of the Northeast region and the world (NJDEP, 2020). Its ci�zens are already experiencing the effects of climate change, from chronic heat to intense flooding and rising sea levels. Recognizing the need for immediate ac�on, in 2021, Governor Murphy signed Execu�ve Order 274 (EO 274), establishing an interim greenhouse gas reduc�on target of 50\% by 2030. This new target, coupled with the State’s previously adopted goal of an 80\% reduc�on by 2050, will require significant near-term investments and comprehensive policy reform. The funding associated with the United States Environmental Protec�on Agency’s (USEPA) Climate Pollu�on Reduc�on Grant program (CPRG) offers a historic opportunity to make substan�al progress towards achieving these goals. About CPRG The CPRG program is a na�onwide, two-phase USEPA grant funded by the Infla�on Reduc�on Act (IRA). Phase 1 provided \$250 million in noncompe��ve planning grants to states and other en��es to develop climate ac�on plans for reducing greenhouse gas emissions and other harmful air pollutants. Phase 2 provides \$4.6 billion in compe��ve grants to implement priority measures included in Priority Climate Ac�on Plans (PCAP). New Jersey’s Priorities The State of New Jersey developed this Priority Climate Ac�on Plan (PCAP), as part of the Phase 1 CPRG grant. This plan builds on the State’s 2019 Energy Master Plan and 2020 Global Warming Response Act 80x50 report to outline a near term roadmap for statewide emission reduc�ons. Six focus areas are iden�fied in this plan: 1) Transporta�on, 2) Residen�al and Commercial Buildings, 3) Electric Genera�on, 4) Food Waste, 5) Halogenated Gases, and 6) Natural and Working Lands (Figure ES 1). These sectors contribute the most to greenhouse gas emissions in New Jersey, or have the poten�al to significantly sequester carbon, and were iden�fied in prior climate planning efforts as key areas on which to focus reduc�on efforts. As part of this PCAP, New Jersey also released an updated Greenhouse Gas Inventory Report, covering statewide emissions from 2006-2021. Similar to preceding years, emissions from the transporta�on sector were the largest source, totaling 37.3 million metrics tons of carbon dioxide equivalent (MMT CO2e) (GWP100). Residen�al and commercial buildings accounted for 14.9 and 9.9 MMT CO2e in 2021 respec�vely, while emissions from the electric genera�on sector were 19.1 MMT CO2e. Emissions from the State’s waste management sector, which includes food waste, were 6.6 MMT CO2e and hydrofluorocarbons (HFCs) which are commonly used halogenated gases, accounted for 5.2 MMT CO2e in 2021. Finally, approximately 8.1 MMT of New Jersey’s 2021 GHG emissions were removed via carbon sequestra�on from the State’s natural and working lands, such as forests and wetlands, resul�ng in a net statewide emission total of 97.6 MMT CO2e in 2021. Figure ES. 1 New Jersey’s PCAP Priority Focus Areas  iv | PRIORITY CLIMATE ACTION PLAN State agencies iden�fied 12 priority measures and 68 enabling ac�ons within these sectors (Table ES.1). These measures were developed with extensive stakeholder input and intergovernmental collabora�on, reflec�ng the voices of communi�es and their leaders. Further, each measure was evaluated for its poten�al to reduce greenhouse gas emissions and benefit low-income and disadvantaged communi�es (See Chapter 4 and Appendix 7.4). New Jersey also conducted a workforce planning analysis to understand workforce needs related to successful implementa�on of the priority measures (See Chapter 5 and Appendix 7.5). This PCAP will serve as a guiding document for State and local agencies to secure federal funding to reduce greenhouse gas emissions.}
 }
 
-@report{newpragueutilitiescommissionAgendaPacket242022,
+@report{newpragueutilitiescommissionAgendaPacket12022,
   type = {Utility},
   title = {Agenda \& {{Packet}}, 1/24/2022 Meeting of the {{New Prague Utilities Commission}} (Incl. Financial Report)},
   author = {{New Prague Utilities Commission}},
@@ -3439,7 +3471,7 @@
   keywords = {Artificial intelligence,Image segmentation,Multi-scale datasets,Text-prompt technique}
 }
 
-@report{padepCommonwealthPennsylvaniaPriority2024,
+@report{padepCommonwealthPennsylvaniasPriority2024,
   type = {Government},
   title = {Commonwealth of {{Pennsylvania}}’s {{Priority Climate Action Plan}}},
   shorttitle = {Pennsylvania {{PCAP}}},
@@ -3544,7 +3576,7 @@
   langid = {english}
 }
 
-@report{polkcountypublicworksWhatNextCentral2024,
+@report{polkcountypublicworksWhatsNextCentral2024,
   type = {Government},
   title = {What's next {{Central Iowa}}? {{Central Iowa Priority Climate Action Plan}}},
   shorttitle = {Central {{IA PCAP}}},
@@ -3754,7 +3786,7 @@
   url = {https://www.epa.gov/system/files/documents/2024-03/5d-98t76601-riverside-san-bernardino-ontario-pcap.pdf},
   urldate = {2024-03-05},
   abstract = {This Priority Climate Action Plan (PCAP) serves as a high-level roadmap for reducing greenhouse gas (GHG) emissions throughout the Riverside−San Bernardino−Ontario metropolitan statistical area (MSA), which includes the Counties of Riverside and San Bernardino, California. Three councils of government represent the city and county governments in the MSA: Coachella Valley Association of Governments (CVAG), San Bernardino Council of Governments (SBCOG), and Western Riverside Council of Governments (WRCOG). The PCAP builds from a strong foundation of state, regional, and local policies as well as GHG inventories and existing climate action plans (CAPs) that have been developed by these sub-regional government agencies as well as local governments throughout the region. The lead organization for purposes of the Climate Pollution Reduction Grants (CPRG) Planning Grant Program is the San Bernardino County Transportation Authority (SBCTA)/San Bernardino Council of Governments (SBCOG).1 Henceforth, will be referred to as SBCOG. This PCAP provides a plan to reduce GHG emissions for the entire MSA based on a compilation of existing and new analysis that includes GHG inventories across all sectors (energy, transportation, solid waste, water \& wastewater, and agriculture), assessment of reduction potential across each sector based on existing climate action plans, and the development of three regional measures deemed by stakeholders to be the highest priorities for implementation based on their near-term GHG reduction potential, need for funding, and anticipated co-benefits to low income and disadvantaged communities (LIDACs), to name a few key prioritization criteria. In addition, the PCAP assesses the cost of implementing the regional measures, the authority of the MSA’s local jurisdictions and agencies to implement the measures, and the workforce implications of implementing each measure. Existing GHG Inventories and Climate Action Plans Many local jurisdictions in California have looked to provide consistency with the state’s GHG targets (e.g., 2030, 2045, and 2050) by developing local GHG inventories and CAPs. The state’s latest scoping plan (2022) for addressing climate change emphasized that when establishing GHG reduction targets, local governments should consider their respective share of the statewide reductions necessary to achieve the state’s long-term climate target for each target year, and to best support those overall goals.2 The California Air Resource Board (CARB) recommends that 1 SBCTA and SBCOG are a dual entity, with transportation being the focus of SBCTA. In 2016, the agency sponsored Senate Bill 1305 (Morrell), consolidating the County Transportation Commission, local transportation authority, service authority for freeway emergencies and local congestion management agency into a single entity, San Bernardino County Transportation Authority. The bill passed through both houses and was signed by the Governor in August 2016; it became effective January 1, 2017. (San Bernardino Associated Governments continues as a Joint Powers Authority functioning as a Council of Governments (SBCOG). 2 See California’s 2022 Scoping Plan for Achieving Carbon Neutrality: https://ww2.arb.ca.gov/sites/default/files/2023-04/2022-sp.pdf  1.Introduction Riverside−San Bernardino−Ontario MSA ES-2 March 1, 2024 Priority Climate Action Plan jurisdictions focus on developing locally appropriate, plan-level targets that align with the California trajectory to carbon neutrality. The foundation of existing CAPs in the region include the Western Riverside Subregional CAP originally completed by WRCOG in 2014 and updated in 2022, and the San Bernardino Regional Greenhouse Gas Reduction Plan originally completed by the SBCTA/SBCOG in 2014 and updated in 2021. In addition, more than 25 local CAPs have been completed in the region since 2010, including 7 in the WRCOG subregion, 8 in the SBCOG subregion, and 10 in the CVAG subregion. These efforts are described in more detail in Chapter 2, Existing Climate Action in the Region. The Subregional CAPs developed for the SBCOG and WRCOG subregions include emissions targets that align with the California goal of reducing emissions levels statewide to 40 percent below 1990 levels by 2030. Neither of these CAPs, however, provide emissions targets beyond 2030. Partnerships including the Inland Regional Energy Network (IREN)3 provide programs and support for the energy sector in conjunction with these local climate actions. Often operating in conjunction with climate action planning, GHG inventories serve to track GHG emissions within a defined geographic region and serve as the basis for establishing emissions forecasts and reduction targets. GHG inventories for the member jurisdictions of SBCOG and WRCOG were recently updated when the subregional CAPs were updated for those subregions, while a new subregional GHG emissions inventory was created for the CVAG subregion as part of this PCAP. These subregional GHG inventories are summarized below by sector in Table ES-1 and Figure ES-1, along with an estimate of total emissions for the region.4 The totals by sector indicate that on-road transportation contributes the largest share of regional emissions, at 50.8 percent, followed by building energy (consumption of natural gas and electricity) at 35.4 percent, solid waste disposed at landfills at 6.0 percent, mobile offroad equipment and agriculture each at 3.0 percent, water conveyance at 1.2 percent, and wastewater treatment at 0.6 percent. The inventory results indicate clearly that the biggest opportunities to achieve deep reductions in regional GHG emissions are within the on-road transportation and building energy sectors, which both play a critical role in the regional economy. The GHG reduction measures found in the MSA’s existing local and subregional CAPs, as well as the collective subregional GHG inventories, inform the efforts of this PCAP. The PCAP builds on the existing measures to establish a more cohesive, regional approach to reducing GHG emissions. The PCAP does not represent an exhaustive list of all possible local and regional measures for reducing emissions, but rather an early-stage framework that sets the stage for a more coordinated Comprehensive Climate Action Plan (CCAP) that will advance long term climate action and sustainability across the MSA.},
-  keywords = {Regional PCAP}
+  keywords = {OD GHG Transportation,Regional PCAP,Transportation,transportation ghg method: other}
 }
 
 @report{schererResponsibilitiesProceduresRegulations2017,
@@ -3908,7 +3940,7 @@ Last Modified: 2017-11-16T02:18+08:00}
   location = {Prior Lake, MN},
   url = {https://www.epa.gov/system/files/documents/2024-04/shakopee-mdewakanton-sioux-community-pcap.pdf},
   urldate = {2024-05-24},
-  abstract = {This Priority Climate Action Plan (PCAP) was developed by the Shakopee Mdewakanton Sioux Community (SMSC). The PCAP was created under the Climate Pollution Reduction Grant (CPRG) program, authorized under the Inflation Reduction Act. Within the guidelines of this program, the SMSC has completed this PCAP to identify priority greenhouse gas reduction measures in preparation for implementation. This PCAP builds upon the SMSC’s existing Sustainability Plan that seeks to achieve carbon neutrality by 2035 and work toward a sustainable future that meets the needs of future generations. CPRG OVERVIEW The 2022 Inflation Reduction Act (IRA) established the Climate Pollution Reduction Grants program within the Environmental Protection Agency. The program provides up to \$5 billion in grants over two distinct but related phases: 1. Planning grants: \$250 million was made available for states, U.S. territories, municipalities, air pollution control agencies, and tribes to develop plans that identify priority measures to reduce greenhouse gas emissions. 2. Implementation grants: \$4.6 billion is available for competitive grants to eligible applicants to implement GHG reduction measures identified under a PCAP developed in the first phase of this program. Funding is available under a general competition and a tribes and territories competition. The CPRG implementation grants represent the largest investment in state, local, and tribal efforts to reduce greenhouse gas emissions, prioritizing those most at risk from air pollution and the increasingly harmful impacts of climate change. As global warming accelerates and disrupts the Earth’s natural systems, communities across the country are facing more deadly wildfires, damaging storms, extreme drought, and water scarcity, among other impacts. Like many other areas of the country, Minnesota is experiencing the effects of a changing climate. Warmer winters disrupt ecosystems, allowing the establishment of invasive species. Poor air quality and more frequent heat waves threaten health and outdoor activities. These changes also threaten the traditional practices of SMSC Community Members, including the impact on the health of maple trees for tapping and rice fields for harvesting. The EPA is committed to its responsibility to protect human health and the environment. Accordingly, the CPRG implementation grant competitions are designed to enable states, municipalities, tribes, and territories to achieve the following goals: 1. Implement ambitious measures to achieve significant cumulative GHG reductions by 2030 and beyond; 2. Pursue measures that will achieve substantial community benefits, particularly in low-income and disadvantaged communities; 3. Complement other funding sources to maximize these GHG reductions and community benefits; and, 4. Pursue innovative policies and programs that are replicable and can be scaled up across multiple jurisdictions. SMSC chose to participate in the CPRG program because of the opportunities offered to 1) complete a more detailed assessment of priority actions to meet GHG reduction goals, and 2) to access available federal funding for the implementation of priority actions. This PCAP details the selected priority GHG reduction measures that the SMSC intends to implement in the near-term and how those measures will affect the Community’s climate goals.},
+  abstract = {This Priority Climate Action Plan (PCAP) was developed by the Shakopee Mdewakanton Sioux Community (SMSC). The PCAP was created under the Climate Pollution Reduction Grant (CPRG) program, authorized under the Inflation Reduction Act. Within the guidelines of this program, the SMSC has completed this PCAP to identify priority greenhouse gas reduction measures in preparation for implementation. This PCAP builds upon the SMSC’s existing Sustainability Plan that seeks to achieve carbon neutrality by 2035 and work toward a sustainable future that meets the needs of future generations. CPRG OVERVIEW The 2022 Inflation Reduction Act (IRA) established the Climate Pollution Reduction Grants program within the Environmental Protection Agency. The program provides up to \textbackslash 5 billion in grants over two distinct but related phases: 1. Planning grants: \textbackslash 250 million was made available for states, U.S. territories, municipalities, air pollution control agencies, and tribes to develop plans that identify priority measures to reduce greenhouse gas emissions. 2. Implementation grants: \$4.6 billion is available for competitive grants to eligible applicants to implement GHG reduction measures identified under a PCAP developed in the first phase of this program. Funding is available under a general competition and a tribes and territories competition. The CPRG implementation grants represent the largest investment in state, local, and tribal efforts to reduce greenhouse gas emissions, prioritizing those most at risk from air pollution and the increasingly harmful impacts of climate change. As global warming accelerates and disrupts the Earth’s natural systems, communities across the country are facing more deadly wildfires, damaging storms, extreme drought, and water scarcity, among other impacts. Like many other areas of the country, Minnesota is experiencing the effects of a changing climate. Warmer winters disrupt ecosystems, allowing the establishment of invasive species. Poor air quality and more frequent heat waves threaten health and outdoor activities. These changes also threaten the traditional practices of SMSC Community Members, including the impact on the health of maple trees for tapping and rice fields for harvesting. The EPA is committed to its responsibility to protect human health and the environment. Accordingly, the CPRG implementation grant competitions are designed to enable states, municipalities, tribes, and territories to achieve the following goals: 1. Implement ambitious measures to achieve significant cumulative GHG reductions by 2030 and beyond; 2. Pursue measures that will achieve substantial community benefits, particularly in low-income and disadvantaged communities; 3. Complement other funding sources to maximize these GHG reductions and community benefits; and, 4. Pursue innovative policies and programs that are replicable and can be scaled up across multiple jurisdictions. SMSC chose to participate in the CPRG program because of the opportunities offered to 1) complete a more detailed assessment of priority actions to meet GHG reduction goals, and 2) to access available federal funding for the implementation of priority actions. This PCAP details the selected priority GHG reduction measures that the SMSC intends to implement in the near-term and how those measures will affect the Community’s climate goals.},
   langid = {english}
 }
 
@@ -4345,11 +4377,6 @@ Last Modified: 2017-11-16T02:18+08:00}
   urldate = {2024-08-30}
 }
 
-@article{UseEPAEmission,
-  title = {Use of {{EPA}}’s {{Emission Factors Hub}}’s {{Waste Emission Factors}} vs. the {{Waste Reduction Model}} ({{WARM}}): {{Guidance}} for {{Organizations}}},
-  langid = {english}
-}
-
 @report{useia2020ResidentialEnergy2023,
   type = {Government},
   title = {2020 {{Residential Energy Consumption Survey}}: {{Consumption}} and {{Expenditures Technical Documentation Summary}}},
@@ -4509,7 +4536,7 @@ Last Modified: 2017-11-16T02:18+08:00}
   urldate = {2023-12-08}
 }
 
-@report{usepaAnnexesInventoryGreenhouse2024,
+@report{usepaAnnexesInventoryUS2024,
   type = {Government},
   title = {Annexes to the {{Inventory}} of {{U}}.{{S}}. {{Greenhouse Gas Emissions}} and {{Sinks}}},
   author = {{USEPA}},
@@ -4621,6 +4648,18 @@ Last Modified: 2017-11-16T02:18+08:00}
   urldate = {2024-01-31},
   abstract = {EPA's GHG Emission Factors Hub was designed to provide organizations with a regularly updated and easy-to-use set of default emission factors for organizational greenhouse gas reporting. Key sources for emission factors include: EPA's Greenhouse Gas Reporting Program EPA's Emissions \& Generation Resource Integrated Database (eGRID) Inventory of U.S. Greenhouse Gas Emissions and Sinks EPA's Waste Reduction Model (WARM) Intergovernmental Panel on Climate Change (IPCC), Fourth Assessment Report (AR4) The most recent version of the Emission Factors Hub (March 2023) includes updates to emission factors for purchased electricity from eGRID, mobile combustion, upstream and downstream transportation, business travel, product transport, and employee commuting. Download the latest version of the Emission Factors Hub as well as previous versions in the table below. Guidance on the use of EPA's Emission Factors Hub's waste emission factors versus the Waste Reduction Model (WARM) is also available.},
   version = {2021}
+}
+
+@report{usepaGHGHubVsWarmGuidance2020,
+  type = {Government},
+  title = {Use of {{EPA}}’s {{Emission Factors Hub}}’s {{Waste Emission Factors}} vs. the {{Waste Reduction Model}} ({{WARM}}): {{Guidance}} for {{Organizations}}},
+  author = {{USEPA}},
+  date = {2020-04},
+  pages = {1--4},
+  url = {https://www.epa.gov/sites/default/files/2020-04/documents/guidanceefwastefactors_vs_warm.pdf},
+  urldate = {2025-01-28},
+  abstract = {EPA developed this resource to help organizations better understand two EPA-developed tools and when the tools may meet the needs of stakeholders. This resource clarifies when organizations should use waste emission factors to develop a Scope 3 GHG emissions inventory and when to use the WARM Tool as a decision-making tool for waste management activities (e.g. recycling) and to communicate the environmental benefits of such efforts.},
+  langid = {english}
 }
 
 @online{usepaGHGReportingProgram23,
@@ -5417,6 +5456,13 @@ Last Modified: 2017-11-16T02:18+08:00}
   urldate = {2024-03-08},
   abstract = {West Virginia has long been a national leader in producing Reliable, Efficient, Affordable, and Local (REAL) energy. By maintaining clean fossil fuels, strengthening the grid, and improving energy efficiency – plugging abandoned gas wells, exploring new technologies such as nuclear and geothermal, and building on existing collaborative networks – the CPRG Planning and Implementation grants will help West Virginia maintain its status within the nation’s energy sector while effectively and efficiently reducing GHG emissions. West Virginia’s CO2 emissions fell 32.9\% from 2005-2020, outpacing reductions in the US at large (25\%) and demonstrating that the allinclusive approach to electric generation does not conflict with appreciable reductions in greenhouse gas emissions (Figure 1.1). These CO2 reductions have primarily been the result of significant transitions in electric power generation across the country, leading to large, negative economic impacts across West Virginia and highlighting the historic interdependence between economic activity, energy consumption, and CO2 emissions. Energy consumption and emissions are dominated by the industrial sector, with 45\% of energy consumption (primary consumption and electricity) from industrial sources (see Figure 1.2). Any successful Energy Action Plan must have a focus on job creation and retention, create equitable economic outcomes for residents of the state, and position West Virginia for both resilient and reliable future energy generation. West Virginia has a disproportionate share of disadvantaged communities as defined by the Climate and Economic Justice Screening Tool, with more than 60\% of census tracts in West Virginia in this category compared to 37\% nationwide. While this highlights the need for outreach to disadvantaged communities, it also illustrates the magnitude of the issue and the need to grow tangible, impactful relationships with, and drive outcomes in, these communities. Finalizing the Priority Energy Action Plan is the first step in this process. Figure 1.1. West Virginia Emissions by Economic Sector, in Million Metric Tons (MMT) of Carbon Dioxide Equivalent (CO2e). Figure 1.2. Emissions by Sector and Energy Consumption by Sector. Source: EPA State Energy Profiles. Source: EIA Beta. 180 160 140 2 120 \textasciitilde{} 1100 S 80 u {$>$}- ::;: 60 ::;: 40 20 0 West Virginia Emissions by Economic Sector, MMT CO2 eq. O"N\textasciitilde{} \textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde O"N\textasciitilde{} \textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde O"Nm \textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde o ;;;;;;;;\textasciitilde;\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde\textasciitilde{} Year WV Energy Consumption by Sector (2019) ■ Industrial ■ Residential ■ Commercial ■ Transportation  EnergyWise West Virginia PEAP March 2024 10 1.1.1 Responsible Entities The State of West Virginia has designated the West Virginia Office of Energy (WVOE) as the Lead Organization under the WV CPRG Planning Grant. The WVOE is the State Agency responsible for the formulation and implementation of fossil, renewable and energy efficiency initiatives designed to advance energy resource development opportunities and provide energy services to businesses, communities, and homeowners in West Virginia. As such, they are responsible for submitting the three (3) key deliverables of West Virginia’s CPRG Planning Grant: 1. Priority Energy Action Plan (PEAP) 2. Comprehensive Energy Action Plan (CEAP), and 3. Status Report 1.1.2 Coordinating Entities The WVOE has identified a strong set of coordinating and partnering organizations to ensure the success of this proposal. The list of coordinating partners includes: ● West Virginia University (WVU) – WVU is the largest university in West Virginia, a public landgrant research university, and the only R1-ranked research university in the state. ● Marshall University (MU) – Marshall is the second largest university in West Virginia and is a public research university. ● In-2-Market, Inc. (I2M) – In-2-Market, Inc. is a Pennsylvania-based 501(c)(3) non-profit corporation serving the tri-state region of Ohio, Pennsylvania, and West Virginia. In-2-Market accelerates industrial innovation with a focus on modern manufacturing, advanced materials, and energy. Cooperative agreements through the form of Memorandums of Understanding have been executed between the organizations to define expectations, roles and responsibilities, and required deliverables. 1.2 CPRG Scope Under this project, the WV CPRG Project Team has identified, evaluated, and utilized existing data resources1 to develop a statewide inventory of the major sources of greenhouse gas (GHG) emissions within West Virginia and used that inventory data to develop an energy action plan. At the inception of the CPRG Planning Grant, the baseline GHG inventory and options analyses developed under this project were designed to be utilized by the WVOE CPRG Project Team for planning purposes to support West Virginia’s development of the following three deliverables: − West Virginia’s Priority Energy Action Plan (PEAP), submitted via this report on March 1, 2024. The plan includes near-term, implementation-ready, priority GHG reduction measures and is a prerequisite for any Implementation Grant. − West Virginia’s Comprehensive Energy Action Plan (CEAP), which is due in 2025. This plan will review all sectors that are significant GHG sources or sinks, and include both near- and longterm GHG emission reduction goals and strategies. 1 EPA, Environmental Information Quality Policy, CIO 2105.3, 03/07/2023 (p. 8) provides common examples of environmental information used to support the EPA’s mission at https://www.epa.gov/system/files/documents/2023-04/environmental\_information\_quality\_policy.pdf.  EnergyWise West Virginia PEAP March 2024 11 − West Virginia’s Status Report on progress towards its goals, due in 2027. This progress report will include updated analyses, plans, and next steps for key metrics. For each deliverable, the Project Team was tasked with completing a series of five subtasks: 1. Develop a comprehensive GHG inventory for the largest sources within each sector, 2. Develop options for reducing emissions within each sector, 3. Develop estimates or ranges of estimates for the reductions achievable under each option, 4. Develop forecasts for economic impacts of the options, and 5. Present the inventory, options listing, and associated analyses in a technical report for consideration by state policymakers with the authority to approve the deliverables under the CPRG planning grants. This report is an accounting of the subtasks for the first deliverable, the Priority Energy Action Plan (PEAP)},
   keywords = {Regional PCAP}
+}
+
+@report{xcelenergyXcelEnergyCommunity,
+  title = {Xcel {{Energy Community Energy Reports}}},
+  author = {Xcel Energy},
+  institution = {Xcel Energy},
+  url = {https://www.xcelenergy.com/community_energy_reports}
 }
 
 @article{yangSoilCarbonSequestration2019,


### PR DESCRIPTION
This PR adds a submodule for working with our regional travel demand modeling outputs. No impact on other sectors, Quarto, etc. 

Closes #159 